### PR TITLE
PLM-3452 Updates to accommodate python 3.10. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ main.py
 
 docs/_build
 tests/failures/*.html
+venv

--- a/README.rst
+++ b/README.rst
@@ -1,41 +1,17 @@
 ######
-PyDocX
+PyDocX - Cert Automation Fork
 ######
 
-.. image:: https://travis-ci.org/CenterForOpenScience/pydocx.png?branch=master
-   :align: left
-   :target: https://travis-ci.org/CenterForOpenScience/pydocx
+### To develop locally
+* Check out the repo
+* create a virtual env: `python3 -m venv ./venv`
+* install the library as editable: `pip install -e .`
 
-* `Installation <https://pydocx.readthedocs.org/en/latest/installation.html>`_
-* `Documentation <https://pydocx.readthedocs.org>`_
-* `Release Notes <https://pydocx.readthedocs.org/en/latest/release_notes.html>`_
-* `Github Page <https://github.com/CenterForOpenScience/pydocx>`_
-* `Issue Tracking <https://github.com/CenterForOpenScience/pydocx/issues>`_
+### To run build tests/docs/linting
+* install `tox`: `pip install tox`
+* run tox: `tox`
 
-PyDocX is a tool
-that can export
-MS Word documents (Office Open XML)
-into different markup languages.
-Currently,
-only HTML is supported.
-You can extend
-any of the available exporters
-to customize it to your needs.
-This includes extending
-the base exporter
-to add support
-for a markup language
-or format
-that is not supported.
-
-To get started using PyDocX,
-see the `Usage <https://pydocx.readthedocs.org/en/latest/usage.html>`_
-guide
-and also
-`Extending PyDocX <https://pydocx.readthedocs.org/en/latest/extending.html>`_.
-
-######
-COS is Hiring!
-######
-
-Want to help save science? Want to get paid to develop free, open source software? `Check out our openings! <http://cos.io/jobs>`_
+### To do a release:
+* PR merge into master (remember to increment version number)
+* tag in GitHub with inremented version number
+* Update requirements.txt in project that uses this repo

--- a/pydocx/__init__.py
+++ b/pydocx/__init__.py
@@ -6,4 +6,4 @@ __all__ = [
     'PyDocX',
 ]
 
-__version__ = '0.9.10'
+__version__ = '0.9.11'

--- a/pydocx/export/html.py
+++ b/pydocx/export/html.py
@@ -854,7 +854,7 @@ class PyDocXHTMLExporter(PyDocXExporter):
         for arg in field_args:
             if bookmark_option is True:
                 bookmark = arg
-            if arg == '\l':
+            if arg == '\\l':
                 bookmark_option = True
         if bookmark_option and bookmark:
             target_uri = '{0}#{1}'.format(target_uri, bookmark)

--- a/pydocx/openxml/wordprocessing/simple_field.py
+++ b/pydocx/openxml/wordprocessing/simple_field.py
@@ -32,7 +32,7 @@ class SimpleField(XmlModel):
     )
 
     def _parse_instr_into_field_type_and_arg_string(self):
-        return re.match('^\s*([^\s]+)\s*(.*)$', self.instr)
+        return re.match(r'^\s*([^\s]+)\s*(.*)$', self.instr)
 
     def _parse_instr_arg_string_to_args(self, arg_string):
         return re.findall(r'\s*(?:"([^"]+)"|([^\s]+))+', arg_string)

--- a/pydocx/util/memoize.py
+++ b/pydocx/util/memoize.py
@@ -5,7 +5,7 @@ from __future__ import (
     unicode_literals,
 )
 
-import collections
+from collections.abc import Hashable
 import functools
 
 
@@ -21,7 +21,7 @@ class memoized(object):
         self.cache = {}
 
     def __call__(self, *args):
-        if not isinstance(args, collections.Hashable):
+        if not isinstance(args, Hashable):
             # uncacheable. a list, for instance.
             # better to not cache than blow up.
             return self.func(*args)

--- a/requirements/testing.txt
+++ b/requirements/testing.txt
@@ -2,3 +2,4 @@ Jinja2>=2.0
 coverage==3.6
 nose==1.3.0
 flake8
+pytest==7.3.1

--- a/tests/export/html/test_xml_vulnerabilities.py
+++ b/tests/export/html/test_xml_vulnerabilities.py
@@ -21,7 +21,7 @@ class XMLVulnerabilitiesTestCase(DocumentGeneratorTestCase):
             defusedxml = None
 
         if defusedxml is None:
-            return
+            pytest.skip('This test case only applies when using defusedxml')
 
         document_xml = '''
             <p>

--- a/tests/export/html/test_xml_vulnerabilities.py
+++ b/tests/export/html/test_xml_vulnerabilities.py
@@ -6,7 +6,7 @@ from __future__ import (
     unicode_literals,
 )
 
-from nose import SkipTest
+import pytest
 
 from pydocx.test import DocumentGeneratorTestCase
 from pydocx.test.utils import WordprocessingDocumentFactory
@@ -21,7 +21,7 @@ class XMLVulnerabilitiesTestCase(DocumentGeneratorTestCase):
             defusedxml = None
 
         if defusedxml is None:
-            raise SkipTest('This test case only applies when using defusedxml')
+            return
 
         document_xml = '''
             <p>
@@ -56,7 +56,7 @@ class XMLVulnerabilitiesTestCase(DocumentGeneratorTestCase):
             defusedxml = None
 
         if defusedxml is None:
-            raise SkipTest('This test case only applies when using defusedxml')
+            raise pytest.skip('This test case only applies when using defusedxml')
 
         document_xml = '''
             <p>

--- a/tests/export/test_docx.py
+++ b/tests/export/test_docx.py
@@ -8,7 +8,7 @@ import base64
 import os
 from tempfile import NamedTemporaryFile
 
-from nose.tools import raises
+from pytest import raises
 
 from pydocx.exceptions import MalformedDocxException
 from pydocx.export.html import PyDocXHTMLExporter
@@ -59,10 +59,10 @@ class ConvertDocxToHtmlTestCase(DocXFixtureTestCaseFactory):
         'track_changes_on',
     )
 
-    @raises(MalformedDocxException)
     def test_raises_malformed_when_relationships_are_missing(self):
-        docx_path = self.get_path_to_fixture('missing_relationships.docx')
-        self.convert_docx_to_html(docx_path)
+        with self.assertRaises(MalformedDocxException):
+            docx_path = self.get_path_to_fixture('missing_relationships.docx')
+            self.convert_docx_to_html(docx_path)
 
     def test_unicode(self):
         docx_path = self.get_path_to_fixture('greek_alphabet.docx')
@@ -120,7 +120,7 @@ def test_has_image():
     assert_html_equal(actual_html, expected_html)
 
 
-@raises(MalformedDocxException)
 def test_malformed_docx_exception():
-    with NamedTemporaryFile(suffix='.docx') as f:
-        convert(f.name)
+    with raises(MalformedDocxException):
+        with NamedTemporaryFile(suffix='.docx') as f:
+            convert(f.name)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -10,7 +10,7 @@ from subprocess import Popen, PIPE
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 
-from nose import SkipTest
+from pytest import skip
 
 from pydocx.__main__ import main
 from pydocx.test.testcases import BASE_HTML
@@ -44,7 +44,7 @@ class MainTestCase(TestCase):
         self.assertEqual(result, 0)
 
     def test_convert_to_markdown_status_code(self):
-        raise SkipTest('Fixture files for markdown do not exist yet')
+        skip('Fixture files for markdown do not exist yet')
 
     def test_convert_to_html_result(self):
         fixture_html = open('tests/fixtures/inline_tags.html').read()
@@ -60,7 +60,7 @@ class MainTestCase(TestCase):
         self.assertEqual(result, 0)
 
     def test_convert_to_markdown_result(self):
-        raise SkipTest('Fixture files for markdown do not exist yet')
+        skip('Fixture files for markdown do not exist yet')
 
     def test_file_handles_to_docx_are_released(self):
         # Copy the docx to another location so we can open it, and delete it

--- a/tox.ini
+++ b/tox.ini
@@ -4,15 +4,15 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = docs, py{27,34}pep8, py{26,27,33,34,py}, py{26,27,33,34,py}-defusedxml, py{27,34}-coverage
+envlist = docs, py310, flake8
+
 
 [testenv]
 commands =
-  nosetests --with-doctest []
+  python -m pytest -vv {posargs}
 deps =
   -rrequirements/testing.txt
   defusedxml: defusedxml==0.4.1
-  py26: importlib
 
 [testenv:docs]
 commands =
@@ -20,24 +20,13 @@ commands =
 deps = -rrequirements/docs.txt
 skipsdist = True
 
-# Coverage for python 2.7 and and 3.4 only
-[testenv:py27-coverage]
-commands =
-  nosetests --with-doctest --with-coverage --cover-package pydocx []
-[testenv:py34-coverage]
-commands =
-  nosetests --with-doctest --with-coverage --cover-package pydocx []
 
-[testenv:py27pep8]
-basepython = python2.7
-deps = flake8
-commands = flake8 pydocx
-
-[testenv:py34pep8]
-basepython = python3.4
+[testenv:flake8]
+basepython = python3.10
 deps = flake8
 commands = flake8 pydocx
 
 [flake8]
 select = E,W,F
 max-line-length = 95
+ignore=W503


### PR DESCRIPTION
* Replace nose with pytest since nose died a while ago and is no longer maintained. 
* Fix some flake8 warnings to get passing build
* Fix hashable import that breaks python 3.10

Note: I've already tagged the forked base version as 0.9.10 so it is safe to merge this into master and re-tag with newer version

full test run (on python 3.10):
```
pip install tox
tox
```

![tox-pydocx](https://user-images.githubusercontent.com/1609427/232902601-9ffd642c-0480-488c-98ca-5dfa213dec70.png)
